### PR TITLE
Fix Rack warning about unprocessable_entity

### DIFF
--- a/lib/generators/admin/install/templates/controllers/admin/users_controller.rb
+++ b/lib/generators/admin/install/templates/controllers/admin/users_controller.rb
@@ -26,7 +26,7 @@ class Admin::UsersController < Admin::BaseController
     if @user.save
       redirect_to @user, notice: "User was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class Admin::UsersController < Admin::BaseController
     if @user.update(user_params)
       redirect_to @user, notice: "User was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/lib/generators/admin/scaffold/templates/controller.rb.tt
+++ b/lib/generators/admin/scaffold/templates/controller.rb.tt
@@ -26,7 +26,7 @@ class <%= controller_class_name %>Controller < Admin::BaseController
     if @<%= orm_instance.save %>
       redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %>
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class <%= controller_class_name %>Controller < Admin::BaseController
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
       redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 


### PR DESCRIPTION
When creating a model with invalid fields, we get an HTTP 422 which is correct but this warning is logged:

> app/controllers/admin/base_controller.rb:13:in `authenticate' gems/rack-3.2.1/lib/rack/utils.rb:584: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.

This was deprecated in Rails 7.1