### PR TITLE
Remove unused system test template from scaffold generator

### DIFF
--- a/lib/generators/admin/scaffold/scaffold_generator.rb
+++ b/lib/generators/admin/scaffold/scaffold_generator.rb
@@ -15,9 +15,7 @@ module Admin
         directory "erb", "app/views/admin/#{file_name.pluralize}"
 
         template "controller.rb", "app/controllers/admin/#{controller_file_name}_controller.rb"
-
         template "functional_test.rb", "test/controllers/admin/#{controller_file_name}_controller_test.rb"
-        template "system_test.rb",     "test/system/admin/#{file_name.pluralize}_test.rb"
       end
 
       def create_routes


### PR DESCRIPTION
This pull request makes a small change to the `copy_files` method in the `scaffold_generator.rb` file. The change removes the generation of system test files for admin scaffolds, so only functional tests will be created going forward.

* Removed the line that generated system test files (`system_test.rb`) for admin scaffolds in `copy_files` within `scaffold_generator.rb`.